### PR TITLE
Allow benchmarking without specifying a label

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ let prettifyTimes = times => {
 };
 
 
-let outputResultsInAPrettyWay = (label, averageTime, executionTimes) => {
+let outputResultsInAPrettyWay = (label = 'untitled', averageTime, executionTimes) => {
 	console.log("Exectuted " + label.bold + " " + executionTimes.length + " times.");
 	console.log("Average duration: " + prettifyTime(averageTime).bold);
 	console.log(("Individual durations: " + prettifyTimes(executionTimes)).grey);


### PR DESCRIPTION
Will default a label of 'untitled' when one is not provided.